### PR TITLE
Partially enable `@phanect/lint-react`

### DIFF
--- a/modules/lint-astro/src/astro.ts
+++ b/modules/lint-astro/src/astro.ts
@@ -10,6 +10,30 @@ export const astro: Linter.Config[] = [
       // For performance
       "astro/no-unused-css-selector": "error",
 
+      //
+      // jsx-a11y
+      //
+      "astro/jsx-a11y/anchor-ambiguous-text": [ "error", {
+        words: [
+          // Defaults
+          "click here",
+          "here",
+          "link",
+          "a link",
+          "learn more",
+
+          // Japanese
+          "ここをクリック",
+          "ここをタップ",
+          "ここ",
+          "こちらをクリック",
+          "こちらをタップ",
+          "こちら",
+          "リンク",
+          "詳細",
+        ],
+      }],
+
       // Disallow `set:html`.
       // I'm not sure if I have chance to use `set:html`, so disallow it for now.
       "astro/no-set-html-directive": "warn",

--- a/modules/lint-react/package.json
+++ b/modules/lint-react/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@phanect/lint-react",
   "version": "2024.10.2",
   "description": "@phanect's personal ESLint config for React & Next.js projects",

--- a/modules/lint-react/package.json
+++ b/modules/lint-react/package.json
@@ -22,7 +22,6 @@
     "lint": "tsc --noEmit && : lint-react"
   },
   "dependencies": {
-    "deepmerge": "^4.3.1",
     "eslint-config-next": "^14.2.12",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react": "^7.36.1",

--- a/modules/lint-react/src/react.ts
+++ b/modules/lint-react/src/react.ts
@@ -12,6 +12,26 @@ export const react: Linter.Config[] = [
     rules: {
       "react/jsx-filename-extension": [ "error", { extensions: [ ".jsx", ".tsx" ]}],
       "react/react-in-jsx-scope": "off",
+      "jsx-a11y/anchor-ambiguous-text": [ "error", {
+        words: [
+          // Defaults
+          "click here",
+          "here",
+          "link",
+          "a link",
+          "learn more",
+
+          // Japanese
+          "ここをクリック",
+          "ここをタップ",
+          "ここ",
+          "こちらをクリック",
+          "こちらをタップ",
+          "こちら",
+          "リンク",
+          "詳細",
+        ],
+      }],
     },
   } satisfies Linter.Config,
 ].map((config) => ({

--- a/modules/lint-react/src/react.ts
+++ b/modules/lint-react/src/react.ts
@@ -1,3 +1,4 @@
+import jsxA11yPlugin from "eslint-plugin-jsx-a11y";
 import reactPlugin from "eslint-plugin-react";
 import type { Linter } from "eslint";
 
@@ -5,6 +6,7 @@ export const react: Linter.Config[] = [
   reactPlugin.configs.flat.recommended as Linter.Config,
   reactPlugin.configs.flat["jsx-runtime"] as Linter.Config,
   // TODO eslint-plugin-react-hooks
+  jsxA11yPlugin.flatConfigs.recommended as Linter.Config,
 
   {
     rules: {

--- a/modules/lint-react/src/react.ts
+++ b/modules/lint-react/src/react.ts
@@ -1,7 +1,5 @@
-import deepmerge from "deepmerge";
-import { core } from "../../lint/src/eslint.ts";
 
-export const react = deepmerge(core, {
+export const react = {
   extends: [
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
@@ -16,8 +14,8 @@ export const react = deepmerge(core, {
     "react/jsx-filename-extension": [ "error", { extensions: [ ".jsx", ".tsx" ]}],
     "react/react-in-jsx-scope": "off",
   },
-});
+};
 
-export const next = deepmerge(react, {
+export const next = {
   extends: [ "next/core-web-vitals" ],
-});
+};

--- a/modules/lint-react/src/react.ts
+++ b/modules/lint-react/src/react.ts
@@ -1,21 +1,23 @@
+import reactPlugin from "eslint-plugin-react";
+import type { Linter } from "eslint";
 
-export const react = {
-  extends: [
-    "plugin:react/recommended",
-    "plugin:react-hooks/recommended",
-  ],
-  plugins: [ "react", "react-hooks" ],
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
+export const react: Linter.Config[] = [
+  reactPlugin.configs.flat.recommended as Linter.Config,
+  reactPlugin.configs.flat["jsx-runtime"] as Linter.Config,
+  // TODO eslint-plugin-react-hooks
+
+  {
+    rules: {
+      "react/jsx-filename-extension": [ "error", { extensions: [ ".jsx", ".tsx" ]}],
+      "react/react-in-jsx-scope": "off",
     },
-  },
-  rules: {
-    "react/jsx-filename-extension": [ "error", { extensions: [ ".jsx", ".tsx" ]}],
-    "react/react-in-jsx-scope": "off",
-  },
-};
+  } satisfies Linter.Config,
+].map((config) => ({
+  ...config,
+  files: [ "**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}" ],
+}));
 
-export const next = {
-  extends: [ "next/core-web-vitals" ],
-};
+/** TODO Not working until @next/eslint-plugin-next supports flat config & ESLint v9+ */
+// export const next = {
+//   extends: [ "next/core-web-vitals" ],
+// };

--- a/modules/lint/README.md
+++ b/modules/lint/README.md
@@ -5,7 +5,7 @@ ESLint config for my own projects.
 ## Install
 
 ```shell
-npm install -D eslint @phanect/lint @phanect/lint-vue @phanect/lint-svelte @phanect/lint-astro
+npm install -D eslint @phanect/lint @phanect/lint-react @phanect/lint-vue @phanect/lint-svelte @phanect/lint-astro
 ```
 
 `@phanect/lint-*` packages are the linter configs for the specific frameworks. Install them if you use them.
@@ -52,9 +52,9 @@ Supported configs:
   - `nodejs`
   - `unbundled`
     - Use this rules in addition to the above rules if the project depends on package.json's `dependencies` on production i.e. npm packages and backend Node.js app without bundling.
-- ~~`@phanect/lint-react`~~ (temporalily inactive)
-  - ~~react~~
-  - ~~next~~
+- `@phanect/lint-react`
+  - react (react-hooks is not included currently because it does not support the flat config yet.)
+  - ~~next~~ (temporalily inactive)
 - `@phanect/lint-vue`
   - `vue`
   - `nuxt`

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@phanect/lint": "2024.10.2",
     "@phanect/utils": "^1.0.0",
     "@types/node": "^22.0.0",
-    "deepmerge": "^4.3.1",
     "eslint": "^9.7.0",
     "esno": "^4.7.0",
     "tsup": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@phanect/configs": "2024.10.2",
     "@phanect/lint": "2024.10.2",
     "@phanect/utils": "^1.0.0",
+    "@types/eslint-plugin-jsx-a11y": "^6.9.0",
     "@types/node": "^22.0.0",
     "eslint": "^9.7.0",
     "esno": "^4.7.0",


### PR DESCRIPTION
Partially Fixes #117

Only enabled `eslint-plugin-react` and `eslint-plugin-jsx-a11y`.
`eslint-plugin-react-hooks` and `@next/eslint-plugin-next` are not yet ready for the flat config.