### PR TITLE
Fix packaging issues of `@phanect/lint-react`

### DIFF
--- a/modules/lint-react/package.json
+++ b/modules/lint-react/package.json
@@ -29,12 +29,12 @@
   "devDependencies": {
     "@phanect/configs": "2024.10.2",
     "@types/node": "^22.0.0",
-    "eslint": "^8.57.1",
+    "eslint": "^9.11.1",
     "tsup": "^8.2.4",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "eslint": "^8.57.1",
+    "eslint": "^9.11.1",
     "next": "*"
   },
   "peerDependenciesMeta": {

--- a/modules/lint-react/package.json
+++ b/modules/lint-react/package.json
@@ -23,8 +23,7 @@
   "dependencies": {
     "@next/eslint-plugin-next": "^14.2.12",
     "eslint-plugin-jsx-a11y": "^6.10.0",
-    "eslint-plugin-react": "^7.36.1",
-    "eslint-plugin-react-hooks": "^4.6.2"
+    "eslint-plugin-react": "^7.36.1"
   },
   "devDependencies": {
     "@phanect/configs": "2024.10.2",

--- a/modules/lint-react/package.json
+++ b/modules/lint-react/package.json
@@ -21,7 +21,7 @@
     "lint": "tsc --noEmit && : lint-react"
   },
   "dependencies": {
-    "eslint-config-next": "^14.2.12",
+    "@next/eslint-plugin-next": "^14.2.12",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react": "^7.36.1",
     "eslint-plugin-react-hooks": "^4.6.2"

--- a/modules/lint-react/package.json
+++ b/modules/lint-react/package.json
@@ -17,7 +17,7 @@
   "module": "./dist/react.js",
   "types": "./dist/react.d.ts",
   "scripts": {
-    "build": ":",
+    "build": "tsup",
     "lint": "tsc --noEmit && : lint-react"
   },
   "dependencies": {


### PR DESCRIPTION
Fix the following problems:

- TypeScript code was not built
- `eslint` package in `peerDependencies` was v8 (old version).