### PR TITLE
Include dist/ directory in the npm package

### DIFF
--- a/workspaces/configs/package.json
+++ b/workspaces/configs/package.json
@@ -15,6 +15,7 @@
   "type": "module",
   "files": [
     "./configs",
+    "./dist",
     "./README.md"
   ],
   "exports": {


### PR DESCRIPTION
tsup configs were not available from `@phanect/config` package.