### PR TITLE
Fix repository URL

### DIFF
--- a/workspaces/configs/package.json
+++ b/workspaces/configs/package.json
@@ -9,9 +9,6 @@
     "type": "git",
     "url": "git+ssh://git@github.com/phanect/misc.git"
   },
-  "bugs": {
-    "url": "https://github.com/phanect/configs/issues"
-  },
   "type": "module",
   "files": [
     "./configs",

--- a/workspaces/configs/package.json
+++ b/workspaces/configs/package.json
@@ -4,10 +4,10 @@
   "description": "Collection of @phanect's personal build configs",
   "author": "Jumpei Ogawa (https://phanective.org)",
   "license": "CC0-1.0",
-  "homepage": "https://github.com/phanect/configs",
+  "homepage": "https://github.com/phanect/misc",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/phanect/configs.git"
+    "url": "git+ssh://git@github.com/phanect/misc.git"
   },
   "bugs": {
     "url": "https://github.com/phanect/configs/issues"

--- a/workspaces/configs/package.json
+++ b/workspaces/configs/package.json
@@ -3,6 +3,7 @@
   "version": "2024.10.3",
   "description": "Collection of @phanect's personal build configs",
   "author": "Jumpei Ogawa (https://phanective.org)",
+  "license": "CC0-1.0",
   "homepage": "https://github.com/phanect/configs",
   "repository": {
     "type": "git",
@@ -11,7 +12,6 @@
   "bugs": {
     "url": "https://github.com/phanect/configs/issues"
   },
-  "license": "CC0-1.0",
   "type": "module",
   "files": [
     "./configs",

--- a/workspaces/lint-astro/package.json
+++ b/workspaces/lint-astro/package.json
@@ -4,6 +4,7 @@
   "description": "@phanect's personal ESLint config for Astro projects",
   "author": "Jumpei Ogawa (https://phanective.org)",
   "license": "CC0-1.0",
+  "homepage": "https://github.com/phanect/misc",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/phanect/misc.git"

--- a/workspaces/lint-react/package.json
+++ b/workspaces/lint-react/package.json
@@ -4,6 +4,7 @@
   "description": "@phanect's personal ESLint config for React & Next.js projects",
   "author": "Jumpei Ogawa (https://phanective.org)",
   "license": "CC0-1.0",
+  "homepage": "https://github.com/phanect/misc",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/phanect/misc.git"

--- a/workspaces/lint-svelte/package.json
+++ b/workspaces/lint-svelte/package.json
@@ -4,6 +4,7 @@
   "description": "@phanect's personal ESLint config for Svelte & SvelteKit projects",
   "author": "Jumpei Ogawa (https://phanective.org)",
   "license": "CC0-1.0",
+  "homepage": "https://github.com/phanect/misc",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/phanect/misc.git"

--- a/workspaces/lint-vue/package.json
+++ b/workspaces/lint-vue/package.json
@@ -4,6 +4,7 @@
   "description": "@phanect's personal ESLint config for Vue.js & Nuxt projects",
   "author": "Jumpei Ogawa (https://phanective.org)",
   "license": "CC0-1.0",
+  "homepage": "https://github.com/phanect/misc",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/phanect/misc.git"

--- a/workspaces/lint/package.json
+++ b/workspaces/lint/package.json
@@ -4,6 +4,7 @@
   "description": "Personal ESLint configuration for Jumpei Ogawa (@phanect)",
   "author": "Jumpei Ogawa (https://phanective.org)",
   "license": "CC0-1.0",
+  "homepage": "https://github.com/phanect/misc",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/phanect/misc.git"

--- a/workspaces/lint/package.json
+++ b/workspaces/lint/package.json
@@ -2,6 +2,12 @@
   "name": "@phanect/lint",
   "version": "2024.10.2",
   "description": "Personal ESLint configuration for Jumpei Ogawa (@phanect)",
+  "author": "Jumpei Ogawa (https://phanective.org)",
+  "license": "CC0-1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/phanect/misc.git"
+  },
   "type": "module",
   "files": [
     "./dist",
@@ -22,16 +28,6 @@
     "build": "tsup",
     "test": "vitest run",
     "lint": "tsc --noEmit && : lint"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/phanect/misc.git"
-  },
-  "author": "Jumpei Ogawa (https://phanective.org)",
-  "license": "CC0-1.0",
-  "engines": {
-    "node": "18.x || 20.x || >=22.x",
-    "npm": ">=10.x"
   },
   "dependencies": {
     "@eslint/js": "^9.7.0",
@@ -68,6 +64,10 @@
     "typescript": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": "18.x || 20.x || >=22.x",
+    "npm": ">=10.x"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
If the repository URL does not match with the current repository, `npm publish` with the `provenance` option causes an error.