### PR TITLE
Add missing `esnext` to `lib`

### DIFF
--- a/workspaces/configs/configs/ts/tsconfig.frontend.json
+++ b/workspaces/configs/configs/ts/tsconfig.frontend.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "declaration": false,
     "moduleResolution": "bundler",
-    "lib": [ "dom" ]
+    "lib": [ "esnext", "dom" ]
   }
 }


### PR DESCRIPTION
`lib` is not inherited from the base, but overwritten.